### PR TITLE
Added Xdebug

### DIFF
--- a/includes/coursework/app/settings.php
+++ b/includes/coursework/app/settings.php
@@ -9,9 +9,9 @@
  * Date: 17/11/2021
  */
 
-//ini_set('display_errors', 'On');
-//ini_set('html_errors', 'On');
-//ini_set('xdebug.trace_output_name', 'session_example.%t');
+ini_set('display_errors', 'On');
+ini_set('html_errors', 'On');
+ini_set('xdebug.trace_output_name', 'AA_coursework.%t');
 
 $app_url = dirname($_SERVER['SCRIPT_NAME']);
 $css_path = $app_url . '/css/coursework_css.css';

--- a/includes/coursework/bootstrap.php
+++ b/includes/coursework/bootstrap.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * Bootstrap File
+ * Bootstrap File creates the app and configures it.
  *
- * Boostrap creates the app and configures it by calling the dependencies, and settings files.
+ * Configures the app by calling the dependencies, and settings files.
  *
- * Author: Jakub Chamera
+ * @author : Jakub Chamera
  * Date: 17/11/2021
  */
 
@@ -13,6 +14,13 @@ require 'vendor/autoload.php';
 $app_path = __DIR__ . '/app/';
 
 $settings = require $app_path . 'settings.php';
+
+$makeXdebugTraces = true;
+
+if ($makeXdebugTraces && function_exists('xdebug_start_trace'))
+{
+    xdebug_start_trace();
+}
 
 $container = new \Slim\Container($settings);
 
@@ -23,3 +31,9 @@ $app = new \Slim\App($container);
 require $app_path . 'routes.php';
 
 $app->run();
+
+if ($makeXdebugTraces && function_exists('xdebug_stop_trace'))
+{
+    xdebug_stop_trace();
+}
+


### PR DESCRIPTION
Trace files work, profile files not working yet. 

FYI: XDEBUG FUNCTIONS SLOW DOWN THE APPLICATION SIGNIFICANTLY !!!!!  IT MIGHT BE BEST TO COMMENT XDEBUG OUT WHEN UPLOADING TO THE LIVE SERVER AND DEVELOPING IN DEV!

The added if statements in bootstrap can be commented out to stop Xdebug writing files. This is the easiest way to disable xdebug and is encouraged.